### PR TITLE
Update MATLAB.gitignore

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -15,6 +15,9 @@
 *.mlappinstall
 *.mltbx
 
+# Compiled deployable archives
+*.ctf
+
 # Generated helpsearch folders
 helpsearch*/
 


### PR DESCRIPTION
added entry for ctf artifacts

**Reasons for making this change:**
missing generated artifact type

