### PR TITLE
Update MATLAB.gitignore

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -29,5 +29,8 @@ codegen/
 # Cache files
 *.slxc
 
+# Cached buildtool data
+.buildtool/**
+
 # Cloud based storage dotfile
 .MATLABDriveTag


### PR DESCRIPTION
Added ignore for cached data produced by buildtool

**Reasons for making this change:**
These are local cache results from execution of buildtool.  We should ignore this cache folder.


