### PR TITLE
buildtool support in MATLAB.gitignore

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -26,5 +26,8 @@ codegen/
 # Cache files
 *.slxc
 
+# Buildtool cache folder
+.buildtool/
+
 # Cloud based storage dotfile
 .MATLABDriveTag


### PR DESCRIPTION
**Reasons for making this change:**
Adding support to ignore buildtool cache folders.


